### PR TITLE
Add snippet and syntax highlighting for Mocha context.

### DIFF
--- a/Snippets/context.sublime-snippet
+++ b/Snippets/context.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+  <content><![CDATA[
+context '${1}', ->
+  ${2}
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>context</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.coffee</scope>
+</snippet>
+

--- a/Syntaxes/Mocha Chai CoffeeScript.YAML-tmLanguage
+++ b/Syntaxes/Mocha Chai CoffeeScript.YAML-tmLanguage
@@ -12,11 +12,23 @@ patterns:
   match: (?<!\.)\b(beforeEach|afterEach)\b(?![?!])
 - name: entity.name.class.coffee
   match: \@\w+\b
+- include: '#context'
 - include: '#describe'
 - include: '#it'
 - include: source.coffee
 
 repository:
+  context:
+    name: meta.coffee.behaviour
+    begin: ^\s*(x?context)\b
+    beginCaptures:
+      '1': {name: keyword.other.coffee.behaviour}
+    end: $
+    endCaptures:
+      '1': {name: keyword.control.coffee.start-block}
+    patterns:
+    - include: source.coffee
+
   describe:
     name: meta.coffee.behaviour
     begin: ^\s*(x?describe)\b

--- a/Syntaxes/Mocha Chai CoffeeScript.tmLanguage
+++ b/Syntaxes/Mocha Chai CoffeeScript.tmLanguage
@@ -31,6 +31,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#context</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#describe</string>
 		</dict>
 		<dict>
@@ -44,6 +48,38 @@
 	</array>
 	<key>repository</key>
 	<dict>
+		<key>context</key>
+		<dict>
+			<key>begin</key>
+			<string>^\s*(x?context)\b</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.coffee.behaviour</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>$</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.coffee.start-block</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.coffee.behaviour</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.coffee</string>
+				</dict>
+			</array>
+		</dict>
 		<key>describe</key>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
Mocha supports `context` as a synonym for `describe`. This adds a snippet and syntax highlighting for it.
