### PR TITLE
Add support for before, after, and afterEach

### DIFF
--- a/Snippets/after.sublime-snippet
+++ b/Snippets/after.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+  <content><![CDATA[
+after ->
+  ${1}
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>after</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.coffee</scope>
+</snippet>
+

--- a/Snippets/afterEach.sublime-snippet
+++ b/Snippets/afterEach.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+  <content><![CDATA[
+afterEach ->
+  ${1}
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>after</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.coffee</scope>
+</snippet>
+

--- a/Snippets/before.sublime-snippet
+++ b/Snippets/before.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+  <content><![CDATA[
+before ->
+  ${1}
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>before</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.coffee</scope>
+</snippet>
+

--- a/Syntaxes/Mocha Chai CoffeeScript.YAML-tmLanguage
+++ b/Syntaxes/Mocha Chai CoffeeScript.YAML-tmLanguage
@@ -7,7 +7,7 @@ uuid: 5c87cc44-13de-49bb-9c01-b8db446071d6
 
 patterns:
 - name: keyword.other.coffee
-  match: (?<!\.)\b(beforeEach|afterEach)\b(?![?!])
+  match: (?<!\.)\b(before|after)\b(?![?!])
 - name: keyword.other.coffee
   match: (?<!\.)\b(beforeEach|afterEach)\b(?![?!])
 - name: entity.name.class.coffee

--- a/Syntaxes/Mocha Chai CoffeeScript.tmLanguage
+++ b/Syntaxes/Mocha Chai CoffeeScript.tmLanguage
@@ -13,7 +13,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\.)\b(beforeEach|afterEach)\b(?![?!])</string>
+			<string>(?&lt;!\.)\b(before|after)\b(?![?!])</string>
 			<key>name</key>
 			<string>keyword.other.coffee</string>
 		</dict>


### PR DESCRIPTION
Fix duplicate syntax highlighting definition and replace with missing support for `before` and `after`. Also add snippets for `before`, `after`, and `afterEach`.
